### PR TITLE
message reply fixes

### DIFF
--- a/lib/global/libs/matrix/events.dart
+++ b/lib/global/libs/matrix/events.dart
@@ -106,6 +106,7 @@ abstract class Events {
   static Future<dynamic> sendMessageEncrypted({
     String protocol = 'https://',
     String homeserver = 'matrix.org',
+    Map unencryptedData,
     String accessToken,
     String trxId,
     String roomId,
@@ -128,6 +129,10 @@ abstract class Events {
       "session_id": sessionId, // "<outbound group session id>",
       "device_id": deviceId, // "<our device ID>"
     };
+
+    if (unencryptedData != null) {
+      body.addAll(unencryptedData);
+    }
 
     final response = await http.put(
       url,

--- a/lib/store/crypto/events/actions.dart
+++ b/lib/store/crypto/events/actions.dart
@@ -44,9 +44,8 @@ ThunkAction<AppState> encryptMessageContent({
       'room_id': roomId,
     };
 
-    // Canoncially encode the json for encryption
-    final encodedPayload = canonicalJson.encode(payload);
-    final serializedPayload = utf8.decode(encodedPayload);
+    // Encode the json for encryption
+    final serializedPayload = json.encode(payload);
     final encryptedPayload = outboundMessageSession.encrypt(serializedPayload);
 
     // save the outbound session after processing content

--- a/lib/store/events/actions.dart
+++ b/lib/store/events/actions.dart
@@ -324,8 +324,6 @@ ThunkAction<AppState> formatMessageReply(
 ) {
   return (Store<AppState> store) async {
     try {
-      // The below screws up Element Web's ability to parse JSON for some reason
-      // TODO
       final body = '''> <${reply.sender}> ${reply.body}\n\n${message.body}''';
       final formattedBody =
           '''<mx-reply><blockquote><a href="https://matrix.to/#/${room.id}/${reply.id}">In reply to</a><a href="https://matrix.to/#/${reply.sender}">${reply.sender}</a><br />${reply.formattedBody ?? reply.body}</blockquote></mx-reply>${message.formattedBody ?? message.body}''';

--- a/lib/store/events/actions.dart
+++ b/lib/store/events/actions.dart
@@ -324,6 +324,8 @@ ThunkAction<AppState> formatMessageReply(
 ) {
   return (Store<AppState> store) async {
     try {
+      // The below screws up Element Web's ability to parse JSON for some reason
+      // TODO
       final body = '''> <${reply.sender}> ${reply.body}\n\n${message.body}''';
       final formattedBody =
           '''<mx-reply><blockquote><a href="https://matrix.to/#/${room.id}/${reply.id}">In reply to</a><a href="https://matrix.to/#/${reply.sender}">${reply.sender}</a><br />${reply.formattedBody ?? reply.body}</blockquote></mx-reply>${message.formattedBody ?? message.body}''';
@@ -336,6 +338,9 @@ ThunkAction<AppState> formatMessageReply(
           "body": body,
           "format": "org.matrix.custom.html",
           "formatted_body": formattedBody,
+          // m.relates_to below is not necessary in the unencrypted part of the
+          // message according to the spec but Element web and android seem to
+          // do it so I'm leaving it here
           "m.relates_to": {
             "m.in_reply_to": {"event_id": "${reply.id}"}
           },

--- a/lib/store/events/messages/actions.dart
+++ b/lib/store/events/messages/actions.dart
@@ -160,10 +160,15 @@ ThunkAction<AppState> sendMessageEncrypted({
         syncing: true,
       );
 
+      var unencryptedData = {};
+
       if (reply != null && reply.body != null) {
         pending = await store.dispatch(
           formatMessageReply(room, pending, reply),
         );
+        unencryptedData["m.relates_to"] = {
+          "m.in_reply_to": {"event_id": "${reply.id}"}
+        };
       }
 
       store.dispatch(SaveOutboxMessage(
@@ -183,6 +188,7 @@ ThunkAction<AppState> sendMessageEncrypted({
       final data = await MatrixApi.sendMessageEncrypted(
         protocol: protocol,
         homeserver: store.state.authStore.user.homeserver,
+        unencryptedData: unencryptedData,
         accessToken: store.state.authStore.user.accessToken,
         trxId: DateTime.now().millisecond.toString(),
         roomId: room.id,


### PR DESCRIPTION
According to the spec:
![image](https://user-images.githubusercontent.com/37966924/106938002-5486e480-6716-11eb-9b03-f784f62ed900.png)
the `m.relates_to` key should not be encrypted as part of the message. Despite this, Element Android was able to render encrypted replies using the formatted body fallback, but this was not the case for Element web and other clients relying solely on rich replies. To fix this, I moved the `m.relates_to` key to out of the encrypted part of the message. I left the encrypted version in still, as it seems the Elements do this also, but I have commented on it, and it can probably be removed.

There is also another bug preventing replies from being rendered in Element Web, and this gave me a bit of a headache, but essentially the `body` part seems to be unable to be JSON decoded by Element Web, causing errors such as these:
![image](https://user-images.githubusercontent.com/37966924/106939023-9d8b6880-6717-11eb-9b44-1d603c48be5d.png)
So far, I have not figured out why that is, or whether it's an Element Web or Syphon bug, but I also intend to fix this as part of this PR.

EDIT: It seems like any and all newlines under the `body` key (and possibly others) trip up Element Web. This does not affect Element Android so I'll open an issue on Element's side.