### PR TITLE
Fixes #272 - iOS keyboard theme matches app settings

### DIFF
--- a/lib/global/themes.dart
+++ b/lib/global/themes.dart
@@ -153,11 +153,13 @@ class Themes {
         break;
     }
 
-    final invertedPrimaryColor = brightness == Brightness.light ? primaryColor : accentColor;
+    final invertedPrimaryColor =
+        brightness == Brightness.light ? primaryColor : accentColor;
 
     return ThemeData(
       // Main Colors
       primaryColor: Color(primaryColor),
+      primaryColorBrightness: brightness,
       primaryColorDark: Color(primaryColor),
       primaryColorLight: Color(primaryColor),
       accentColor: Color(accentColor),
@@ -178,7 +180,9 @@ class Themes {
         selectionHandleColor: Color(primaryColor),
       ),
       iconTheme: IconThemeData(color: iconColor),
-      scaffoldBackgroundColor: scaffoldBackgroundColor != null ? Color(scaffoldBackgroundColor) : null,
+      scaffoldBackgroundColor: scaffoldBackgroundColor != null
+          ? Color(scaffoldBackgroundColor)
+          : null,
       appBarTheme: AppBarTheme(
         elevation: appBarElevation,
         brightness: Brightness.dark,


### PR DESCRIPTION
### Types
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (fix or feature that would cause existing functionality to not work as expected)
- [ ] Breaking change (non-breaking change which improves code quality - QA thoroughly)

### Changes
add `primaryColorBrightness:` to `ThemeData` which causes the soft keyboard to respect the chosen theme. Currently only on iOS. 

Details here: https://stackoverflow.com/questions/57619369/how-to-change-flutter-app-keyboard-color

It also looks like it refactored 2 lines for length. I use the Flutter tools for vscode so I left that as I believe that is the recommended formatting, but I can undo those easily if you'd prefer. 

#### 🔮 Features
Keyboard theme
#### 🔒 Security 
#### 🛠 Performance
#### 🐛 Fixes
#### 📐 Refactoring

### Media (if applicable)
    
### QA

- [ ] Signup
- [ ] Login
- [ ] Logout
- [ ] Unencrypted Chat 
- [ ] Encrypted Chat 
- [ ] Group Chats
- [ ] Profile Changes
- [x] Theming Changes
- [ ] Force Kill and Restart

### Final Checklist
 
- [ ] All associated issues have been linked to PR
- [ ] All necessary changes made to the documentation
- [ ] Parties interested in these changes have been notified
