### PR TITLE
[Refactoring] Replace default string value 'matrix.org' by global const Values.homeserverDefault

### DIFF
--- a/lib/global/formatters.dart
+++ b/lib/global/formatters.dart
@@ -6,7 +6,7 @@ String formatSender(String sender) {
   return sender.replaceAll('@', '').split(':')[0];
 }
 
-String formatUserId(String displayName, {String homeserver = 'matrix.org'}) {
+String formatUserId(String displayName, {String homeserver = Values.homeserverDefault}) {
   return '@$displayName:$homeserver';
 }
 

--- a/lib/global/libs/matrix/auth.dart
+++ b/lib/global/libs/matrix/auth.dart
@@ -282,7 +282,7 @@ abstract class Auth {
   ///  Used to check what types of logins are available on the server
   static Future<dynamic> checkUsernameAvailability({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? username,
   }) async {
     String url = '$protocol$homeserver/_matrix/client/r0/register/available';
@@ -301,7 +301,7 @@ abstract class Auth {
   ///  Used to check what types of logins are available on the server
   static Future<dynamic> checkHomeserver({
     String protocol = 'https://',
-    String homeserver = 'matrix.org',
+    String homeserver = Values.homeserverDefault,
   }) async {
     final String url = '$protocol$homeserver/.well-known/matrix/client';
 
@@ -312,7 +312,7 @@ abstract class Auth {
 
   static Future<dynamic> checkVersion({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
   }) async {
     final String url = '$protocol$homeserver/_matrix/client/versions';
 

--- a/lib/global/libs/matrix/devices.dart
+++ b/lib/global/libs/matrix/devices.dart
@@ -11,7 +11,7 @@ abstract class Devices {
   /// Gets all currently active pushers for the authenticated user.
   static Future<dynamic> fetchDevices({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
   }) async {
     final String url = '$protocol$homeserver/_matrix/client/r0/devices';
@@ -31,7 +31,7 @@ abstract class Devices {
   /// Gets all currently active pushers for the authenticated user.
   static Future<dynamic> updateDevice({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? deviceId,
     String? displayName,
@@ -63,7 +63,7 @@ abstract class Devices {
  */
   static Future<dynamic> deleteDevice({
     String protocol = 'https://',
-    String homeserver = 'matrix.org',
+    String homeserver = Values.homeserverDefault,
     String? accessToken,
     String? deviceId,
     String? session,
@@ -118,7 +118,7 @@ abstract class Devices {
  */
   static Future<dynamic> deleteDevices({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     List<String?>? deviceIds,
     String? session,

--- a/lib/global/libs/matrix/encryption.dart
+++ b/lib/global/libs/matrix/encryption.dart
@@ -27,7 +27,7 @@ abstract class Encryption {
   /// Returns the current devices and identity keys for the given users.
   static Future<dynamic> fetchKeys({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     int timeout = 10 * 1000, // 10 seconds
     String? lastSince,
@@ -62,7 +62,7 @@ abstract class Encryption {
   /// Returns the current devices and identity keys for the given users.
   static Future<dynamic> fetchRoomKeys({
     String protocol = 'https://',
-    String homeserver = 'matrix.org',
+    String homeserver = Values.homeserverDefault,
     String? accessToken,
     int timeout = 10 * 1000, // 10 seconds
     String? lastSince,
@@ -96,7 +96,7 @@ abstract class Encryption {
   ///
   static Future<dynamic> fetchKeyChanges({
     String protocol = 'https://',
-    String homeserver = 'matrix.org',
+    String homeserver = Values.homeserverDefault,
     String? accessToken,
     String? from,
     String? to,
@@ -123,7 +123,7 @@ abstract class Encryption {
   ///
   static Future<Map<String, dynamic>> claimKeys({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     Map? oneTimeKeys,
   }) async {
@@ -150,7 +150,7 @@ abstract class Encryption {
 
   static Future<dynamic> uploadKeys({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     Map? data,
   }) async {
@@ -179,7 +179,7 @@ abstract class Encryption {
   ///
   static Future<dynamic> requestKeys({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? requestId,
     String? roomId,

--- a/lib/global/libs/matrix/events.dart
+++ b/lib/global/libs/matrix/events.dart
@@ -15,7 +15,7 @@ abstract class Events {
   /// Get the state events for the current state of a room.
   static Future<dynamic> fetchStateEvents({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? roomId,
   }) async {
@@ -39,7 +39,7 @@ abstract class Events {
   /// https://matrix.org/docs/spec/client_server/latest#id261
   static Future<dynamic> fetchMessageEvents({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? roomId,
     String? from,
@@ -97,7 +97,7 @@ abstract class Events {
 
   static Future<dynamic> sendMessageEncrypted({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     Map? unencryptedData,
     String? accessToken,
     String? trxId,
@@ -147,7 +147,7 @@ abstract class Events {
   /// it will be used by the server to ensure idempotency of requests. <- really a requestId
   static Future<dynamic> sendEvent({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? roomId,
     String? eventType,
@@ -184,7 +184,7 @@ abstract class Events {
   /// it will be used by the server to ensure idempotency of requests. <- really a requestId
   static Future<dynamic> sendMessage({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? roomId,
     String? trxId,
@@ -235,7 +235,7 @@ abstract class Events {
   /// it will be used by the server to ensure idempotency of requests. <- really a requestId
   static Future<dynamic> sendReaction({
     String protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? reaction,
     String? roomId,
@@ -274,7 +274,7 @@ abstract class Events {
   ///
   static Future<dynamic> redactEvent({
     String protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? roomId,
     String? eventId,
@@ -310,7 +310,7 @@ abstract class Events {
   /// The device ID may also be *, meaning all known devices for the user.
   static Future<dynamic> sendEventToDevice({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String trxId = '0', // just a random string to denote uniqueness
     String? eventType,
@@ -343,7 +343,7 @@ abstract class Events {
   /// Send Typing Event
   static Future<dynamic> sendTyping({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? roomId,
     String? userId,
@@ -376,7 +376,7 @@ abstract class Events {
   /// https://matrix.org/docs/spec/client_server/latest#post-matrix-client-r0-rooms-roomid-receipt-receipttype-eventid
   static Future<dynamic> sendReadMarkers({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? roomId,
     String? messageId,

--- a/lib/global/libs/matrix/media.dart
+++ b/lib/global/libs/matrix/media.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'package:syphon/global/values.dart';
 
 /// Media queries for matrix
 ///
@@ -29,7 +30,7 @@ class Media {
 
   static Future<dynamic> fetchThumbnailUnmapped({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? serverName,
     required String mediaUri,
@@ -68,7 +69,7 @@ class Media {
 
   static Future<dynamic> uploadMedia({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? fileName,
     String fileType = 'application/jpeg', // Content-Type: application/pdf
@@ -107,7 +108,7 @@ class Media {
 
 dynamic buildMediaDownloadRequest({
   String protocol = 'https://',
-  String homeserver = 'matrix.org',
+  String homeserver = Values.homeserverDefault,
   String? accessToken,
   String? serverName,
   required String mediaUri,
@@ -133,7 +134,7 @@ dynamic buildMediaDownloadRequest({
 /// Upload some content to the content repository.
 dynamic buildMediaUploadRequest({
   String protocol = 'https://',
-  String homeserver = 'matrix.org',
+  String homeserver = Values.homeserverDefault,
   String? accessToken,
   String? fileName,
   String fileType = 'application/jpeg', // Content-Type: application/pdf

--- a/lib/global/libs/matrix/notifications.dart
+++ b/lib/global/libs/matrix/notifications.dart
@@ -12,7 +12,7 @@ abstract class Notifications {
   /// Gets all currently active pushers for the authenticated user.
   static Future<dynamic> fetchNotifications({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? from,
     int limit = 10,
@@ -44,7 +44,7 @@ abstract class Notifications {
   /// Gets all currently active pushers for the authenticated user.
   static Future<dynamic> fetchNotificationPushers({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
   }) async {
     final String url = '$protocol$homeserver/_matrix/client/r0/pushers';
@@ -87,7 +87,7 @@ abstract class Notifications {
   /// in the JSON body.
   static Future<dynamic> saveNotificationPusher({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? pushKey, // required
     String? kind = 'http', // required

--- a/lib/global/libs/matrix/rooms.dart
+++ b/lib/global/libs/matrix/rooms.dart
@@ -15,7 +15,7 @@ abstract class Rooms {
   /// for new events
   static Future<dynamic> sync({
     String? protocol = 'https://', // http or https ( or libp2p :D )
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? since,
     bool? fullState = false,
@@ -73,7 +73,7 @@ abstract class Rooms {
   /// Sync (filter by roomId)
   static Future<dynamic> syncRoom({
     String protocol = 'https://', // http or https ( or libp2p :D )
-    String homeserver = 'matrix.org',
+    String homeserver = Values.homeserverDefault,
     String? accessToken,
     String? since,
     String? roomId,
@@ -97,7 +97,7 @@ abstract class Rooms {
 
   static Future<dynamic> fetchRoomIds({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? userId,
   }) async {
@@ -117,7 +117,7 @@ abstract class Rooms {
 
   static Future<dynamic> fetchDirectRoomIds({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? userId,
   }) async {
@@ -144,7 +144,7 @@ abstract class Rooms {
   */
   static Future<dynamic> joinRoom({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? roomId,
   }) async {
@@ -180,7 +180,7 @@ abstract class Rooms {
   /// to the room, but had not joined, this call serves to reject the invite.
   static Future<dynamic> createRoom({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? name,
     String? alias,
@@ -238,7 +238,7 @@ abstract class Rooms {
   /// before calling this API.
   static Future<dynamic> leaveRoom({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? roomId,
   }) async {
@@ -275,7 +275,7 @@ abstract class Rooms {
   /// Must leave room before you can forget (The Way)
   static Future<dynamic> forgetRoom({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? roomId,
   }) async {
@@ -309,7 +309,7 @@ abstract class Rooms {
   ///
   static Future<dynamic> deleteRoomAlias({
     String protocol = 'https://',
-    String homeserver = 'matrix.org',
+    String homeserver = Values.homeserverDefault,
     String? accessToken,
     String? roomAlias,
   }) async {
@@ -339,7 +339,7 @@ abstract class Rooms {
   ///
   static Future<dynamic> createFilter({
     String protocol = 'https://',
-    String homeserver = 'matrix.org',
+    String homeserver = Values.homeserverDefault,
     String? accessToken,
     String? userId,
     bool lazyLoading = false,
@@ -379,7 +379,7 @@ abstract class Rooms {
   /// Create a filter to use when fetching room state, messages, or /sync'ing
   static Future<dynamic> fetchFilter({
     String protocol = 'https://',
-    String homeserver = 'matrix.org',
+    String homeserver = Values.homeserverDefault,
     String? accessToken,
     String? roomAlias,
     String? filterId,
@@ -411,7 +411,7 @@ abstract class Rooms {
   ///
   static Future<dynamic> fetchRoomName({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? roomId,
   }) async {

--- a/lib/global/libs/matrix/search.dart
+++ b/lib/global/libs/matrix/search.dart
@@ -19,7 +19,7 @@ import 'package:syphon/global/values.dart';
 class Search {
   static Future<dynamic> searchUsers({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? searchText,
     String? since,
@@ -47,7 +47,7 @@ class Search {
 
   static Future<dynamic> searchRooms({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? searchText,
     String? server,

--- a/lib/global/libs/matrix/user.dart
+++ b/lib/global/libs/matrix/user.dart
@@ -17,7 +17,7 @@ abstract class Users {
   /// to clients in the top-level account_data.
   static Future<dynamic> fetchAccountData({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? userId,
     String type = AccountDataTypes.direct,
@@ -48,7 +48,7 @@ abstract class Users {
   /// to clients in the top-level account_data.
   static Future<dynamic> saveAccountData({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? userId,
     String type = AccountDataTypes.direct,
@@ -81,7 +81,7 @@ abstract class Users {
   /// to clients in the top-level account_data.
   static Future<dynamic> updateBlockedUsers({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? userId,
     Map<String, dynamic> blockUserList = const {},
@@ -117,7 +117,7 @@ abstract class Users {
   /// to clients in the top-level account_data.
   static Future<dynamic> inviteUser({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? roomId,
     String? userId,
@@ -152,7 +152,7 @@ abstract class Users {
   /// e.g. you need to have their access_token.
   static Future<dynamic> fetchUserProfile({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? userId,
   }) async {
@@ -181,7 +181,7 @@ abstract class Users {
   /// e.g. you need to have their access_token.
   static Future<dynamic> updateDisplayName({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? userId,
     String? displayName,
@@ -218,7 +218,7 @@ abstract class Users {
   /// you need to have their access_token.
   static Future<dynamic> updateAvatarUri({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? userId,
     String? avatarUri,
@@ -254,7 +254,7 @@ abstract class Users {
   /// you need to have their access_token.
   static Future<dynamic> deactivateUser({
     String? protocol = 'https://',
-    String? homeserver = 'matrix.org',
+    String? homeserver = Values.homeserverDefault,
     String? accessToken,
     String? userId,
     String? identityServer,
@@ -300,7 +300,7 @@ abstract class Users {
 /// If you have left the room then this will be the members of the room when you left.
 dynamic buildRoomMembersRequest({
   String protocol = 'https://',
-  String homeserver = 'matrix.org',
+  String homeserver = Values.homeserverDefault,
   String? accessToken,
   String? roomId,
 }) {

--- a/lib/store/auth/actions.dart
+++ b/lib/store/auth/actions.dart
@@ -1245,7 +1245,7 @@ ThunkAction<AppState> resolveUsername({String? username}) {
     } else {
       if (!hostname.contains('.')) {
         store.dispatch(setHostname(
-          hostname: homeserver.hostname ?? 'matrix.org',
+          hostname: homeserver.hostname ?? Values.homeserverDefault,
         ));
       }
     }

--- a/lib/store/auth/state.dart
+++ b/lib/store/auth/state.dart
@@ -85,8 +85,8 @@ class AuthStore extends Equatable {
     this.hostname = Values.homeserverDefault,
     this.homeserver = const Homeserver(
       valid: true,
-      hostname: 'matrix.org',
-      baseUrl: 'matrix.org',
+      hostname: Values.homeserverDefault,
+      baseUrl: Values.homeserverDefault,
       loginType: MatrixAuthTypes.DUMMY,
     ),
     this.interactiveAuths = const {},

--- a/lib/views/intro/login/forgot/widgets/PageEmailVerify.dart
+++ b/lib/views/intro/login/forgot/widgets/PageEmailVerify.dart
@@ -187,7 +187,7 @@ class EmailStepState extends State<EmailVerifyStep> {
                   ),
                   child: TextFieldSecure(
                     label: "Homeserver",
-                    hint: 'matrix.org',
+                    hint: Values.homeserverDefault,
                     disableSpacing: true,
                     disabled: props.session,
                     valid: props.isHomeserverValid,


### PR DESCRIPTION
I would like to suggest to replace default string value 'matrix.org' by global const Values.homeserverDefault in func declarations (et al.) to get a single point of default homeserver declaration.

Is there any reason against this?
