### PR TITLE
[fix] set Syphon executable version string on Windows

### DIFF
--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -63,13 +63,13 @@ IDI_APP_ICON            ICON                    "resources\\app_icon.ico"
 #ifdef FLUTTER_BUILD_NUMBER
 #define VERSION_AS_NUMBER FLUTTER_BUILD_NUMBER
 #else
-#define VERSION_AS_NUMBER 1,0,0
+#define VERSION_AS_NUMBER 0,2,3,0
 #endif
 
 #ifdef FLUTTER_BUILD_NAME
 #define VERSION_AS_STRING #FLUTTER_BUILD_NAME
 #else
-#define VERSION_AS_STRING "1.0.0"
+#define VERSION_AS_STRING "0.2.3.0"
 #endif
 
 VS_VERSION_INFO VERSIONINFO


### PR DESCRIPTION
This doesn't fix Flutter not passing versions, but at least versions the exe

### Types
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which improves code quality - QA thoroughly )
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

### Changes

#### 🔮 Features
#### 🔒 Security 
#### 🛠 Performance
#### 🐛 Fixes
Version the Windows executable
#### 📐 Refactoring

### Media (if applicable)
    
### QA

- [ ] Signup
- [ ] Login
- [ ] Logout
- [ ] Unencrypted Chat 
- [ ] Encrypted Chat 
- [ ] Group Chats
- [ ] Profile Changes
- [ ] Theming Changes
- [ ] Force Kill and Restart

### Final Checklist
 
- [ ] All associated issues have been linked to PR
- [ ] All necessary changes made to the documentation
- [ ] Parties interested in these changes have been notified
