### PR TITLE
Change Linux application ID

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 project(runner LANGUAGES CXX)
 
 set(BINARY_NAME "syphon")
-set(APPLICATION_ID "org.tether.tether")
+set(APPLICATION_ID "org.syphon.Syphon")
 
 cmake_policy(SET CMP0063 NEW)
 


### PR DESCRIPTION
### Types
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which improves code quality - QA thoroughly )
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

### Changes
Change the app ID for the Linux build to `org.syphon.Syphon` to match the flatpak. Unlike the mobile apps, this should not be a breaking change, and should help avoid issues like those experienced by FluffyChat: https://github.com/flathub/flathub/pull/1902#discussion_r511417050 (https://github.com/flathub/flathub/pull/1902/files#diff-6e993150725e09c5634e6fdfe96682275f58ef2c870f4e5dcb0278d4216990eaR18)

I went with a capitalised app name to match most apps on flathub, but I can probably still change that to be lowercase if preferred.

#### 🔮 Features
#### 🔒 Security 
#### 🛠 Performance
#### 🐛 Fixes
#### 📐 Refactoring

### Media (if applicable)
    
### QA

- [ ] Signup
- [ ] Login
- [ ] Logout
- [ ] Unencrypted Chat 
- [ ] Encrypted Chat 
- [ ] Group Chats
- [ ] Profile Changes
- [ ] Theming Changes
- [ ] Force Kill and Restart

### Final Checklist
 
- [ ] All associated issues have been linked to PR
- [ ] All necessary changes made to the documentation
- [ ] Parties interested in these changes have been notified
