### PR TITLE
[feature] Respect user read receipts in Syphon

### DIFF
--- a/lib/store/rooms/room/model.dart
+++ b/lib/store/rooms/room/model.dart
@@ -202,7 +202,6 @@ class Room implements drift.Insertable<Room> {
         guestEnabled: json['guest_can_join'],
         worldReadable: json['world_readable'],
         syncing: false,
-        lastRead: json['lastRead'],
       );
     } catch (error) {
       return Room(id: json['room_id']);

--- a/lib/store/rooms/room/model.dart
+++ b/lib/store/rooms/room/model.dart
@@ -202,6 +202,7 @@ class Room implements drift.Insertable<Room> {
         guestEnabled: json['guest_can_join'],
         worldReadable: json['world_readable'],
         syncing: false,
+        lastRead: json['lastRead'],
       );
     } catch (error) {
       return Room(id: json['room_id']);

--- a/lib/store/sync/parsers.dart
+++ b/lib/store/sync/parsers.dart
@@ -129,11 +129,24 @@ Sync parseSync(Map params) {
   // TODO: remove with separate parsers, solve the issue of redundant passes over this data
   final users = Map<String, User>.from(room.usersTEMP);
 
+  int lastRead = room.lastRead;
+
+  ephemerals.readReceipts.forEach((key, value) {
+    if (value.userReadsMapped!.containsKey(currentUser.userId)) {
+      int rr = value.userReadsMapped![currentUser.userId];
+
+      if (rr > lastRead) {
+        lastRead = rr;
+      }
+    }
+  });
+
   final roomUpdated = room.copyWith(
     userTyping: ephemerals.userTyping,
     usersTyping: ephemerals.usersTyping,
     totalJoinedUsers: details.totalMembers,
     usersTEMP: <String, User>{},
+    lastRead: lastRead,
   );
 
   return Sync(

--- a/lib/store/sync/parsers.dart
+++ b/lib/store/sync/parsers.dart
@@ -231,7 +231,7 @@ SyncEphemerals parseEphemerals({
             // convert every m.read object to a map of userIds + timestamps for read
             final receiptsNew = Receipt.fromMatrix(eventId, receipt);
 
-            // update the eventId if that event already has reads
+            // update the read receipts if that event has no reads yet
             if (!readReceipts.containsKey(eventId)) {
               readReceipts[eventId] = receiptsNew;
             } else {

--- a/lib/store/sync/parsers.dart
+++ b/lib/store/sync/parsers.dart
@@ -220,12 +220,6 @@ SyncEphemerals parseEphemerals({
         case 'm.receipt':
           final Map<String, dynamic> receiptEventIds = event.content;
 
-          // TODO: figure out how to pull what messages have been read from read recepts
-          // // Set a new timestamp for the latest read message if it exceeds the current
-          // latestRead = latestRead < newReadStatuses.latestRead
-          //     ? newReadStatuses.latestRead
-          //     : latestRead;
-
           // Filter through every eventId to find receipts
           receiptEventIds.forEach((eventId, receipt) {
             // convert every m.read object to a map of userIds + timestamps for read


### PR DESCRIPTION
### Types
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which improves code quality - QA thoroughly )
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (updates that would not affect or change the code involving the app itself)

### Changes

#### 🔮 Features
Read state is now synced between Syphon instances!
#### 🐛 Fixes
#### 🔒 Security 
#### 🛠 Performance
#### 📐 Refactoring

### Media (if applicable)
    
### QA

- [ ] Signup
- [ ] Login
- [ ] Logout
- [ ] Unencrypted Chat 
- [ ] Encrypted Chat 
- [ ] Group Chats
- [ ] Profile Changes
- [ ] Theming Changes
- [ ] Force Kill and Restart

### Final Checklist
 
- [x] All associated issues have been linked to PR
- [ ] All necessary changes made to the documentation
- [x] Parties interested in these changes have been notified
