### PR TITLE
[hotfix] Only actually fire the resend method when tapped

### DIFF
--- a/lib/views/widgets/messages/message.dart
+++ b/lib/views/widgets/messages/message.dart
@@ -415,7 +415,11 @@ class MessageWidget extends StatelessWidget {
         ),
       ),
       child: GestureDetector(
-        onTap: message.failed ? onResend(message) : null,
+        onTap: () {
+          if (message.failed) {
+            onResend(message);
+          }
+        },
         onLongPress: () {
           if (onLongPress != null) {
             HapticFeedback.lightImpact();


### PR DESCRIPTION
### Types
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which improves code quality - QA thoroughly )
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (updates that would not affect or change the code involving the app itself)

### Changes

#### 🔮 Features
#### 🐛 Fixes
Tap to resend now only tries to resend when actually tapped (fixes https://github.com/syphon-org/syphon/issues/654)
#### 🔒 Security 
#### 🛠 Performance
#### 📐 Refactoring

### Media (if applicable)
    
### QA

- [ ] Signup
- [ ] Login
- [ ] Logout
- [ ] Unencrypted Chat 
- [ ] Encrypted Chat 
- [ ] Group Chats
- [ ] Profile Changes
- [ ] Theming Changes
- [ ] Force Kill and Restart

### Final Checklist
 
- [x] All associated issues have been linked to PR
- [ ] All necessary changes made to the documentation
- [x] Parties interested in these changes have been notified
