### PR TITLE
[fix] Hide Key Management Testing heading behind debug flag

### DIFF
--- a/lib/views/home/settings/settings-intro-screen.dart
+++ b/lib/views/home/settings/settings-intro-screen.dart
@@ -189,12 +189,14 @@ class IntroSettingsScreen extends StatelessWidget {
                               ),
                               trailing: Switch(
                                 value: props.proxyAuthenticationEnabled,
-                                onChanged: (toggle) => props.onToggleProxyAuthentication(),
+                                onChanged: (toggle) =>
+                                    props.onToggleProxyAuthentication(),
                               ),
                             ),
                           ),
                           Visibility(
-                            visible: props.proxyEnabled && props.proxyAuthenticationEnabled,
+                            visible: props.proxyEnabled &&
+                                props.proxyAuthenticationEnabled,
                             child: ListTile(
                               dense: true,
                               onTap: () => props.onEditProxyUsername(context),
@@ -213,7 +215,8 @@ class IntroSettingsScreen extends StatelessWidget {
                             ),
                           ),
                           Visibility(
-                            visible: props.proxyEnabled && props.proxyAuthenticationEnabled,
+                            visible: props.proxyEnabled &&
+                                props.proxyAuthenticationEnabled,
                             child: ListTile(
                               dense: true,
                               onTap: () => props.onEditProxyPassword(context),
@@ -338,7 +341,8 @@ class _Props extends Equatable {
         proxyEnabled: store.state.settingsStore.proxySettings.enabled,
         host: store.state.settingsStore.proxySettings.host,
         port: store.state.settingsStore.proxySettings.port,
-        proxyAuthenticationEnabled: store.state.settingsStore.proxySettings.authenticationEnabled,
+        proxyAuthenticationEnabled:
+            store.state.settingsStore.proxySettings.authenticationEnabled,
         username: store.state.settingsStore.proxySettings.username,
         password: store.state.settingsStore.proxySettings.password,
         onToggleProxy: () async {
@@ -356,7 +360,9 @@ class _Props extends Equatable {
               content: Strings.contentProxyHost,
               label: Strings.labelProxyHost,
               initialValue: store.state.settingsStore.proxySettings.host,
-              inputFormatters: [FilteringTextInputFormatter.singleLineFormatter],
+              inputFormatters: [
+                FilteringTextInputFormatter.singleLineFormatter
+              ],
               onCancel: () async {
                 Navigator.of(dialogContext).pop();
               },
@@ -401,7 +407,9 @@ class _Props extends Equatable {
               content: Strings.contentProxyUsername,
               label: Strings.labelProxyUsername,
               initialValue: store.state.settingsStore.proxySettings.username,
-              inputFormatters: [FilteringTextInputFormatter.singleLineFormatter],
+              inputFormatters: [
+                FilteringTextInputFormatter.singleLineFormatter
+              ],
               onCancel: () async {
                 Navigator.of(dialogContext).pop();
               },
@@ -422,7 +430,9 @@ class _Props extends Equatable {
               content: Strings.contentProxyPassword,
               label: Strings.labelProxyPassword,
               initialValue: store.state.settingsStore.proxySettings.password,
-              inputFormatters: [FilteringTextInputFormatter.singleLineFormatter],
+              inputFormatters: [
+                FilteringTextInputFormatter.singleLineFormatter
+              ],
               obscureText: true,
               onCancel: () async {
                 Navigator.of(dialogContext).pop();

--- a/lib/views/home/settings/settings-intro-screen.dart
+++ b/lib/views/home/settings/settings-intro-screen.dart
@@ -237,13 +237,16 @@ class IntroSettingsScreen extends StatelessWidget {
                     CardSection(
                       child: Column(
                         children: [
-                          Container(
-                            width: width,
-                            padding: Dimensions.listPadding,
-                            child: Text(
-                              'Key Management Testing',
-                              textAlign: TextAlign.start,
-                              style: Theme.of(context).textTheme.subtitle2,
+                          Visibility(
+                            visible: DEBUG_MODE,
+                            child: Container(
+                              width: width,
+                              padding: Dimensions.listPadding,
+                              child: Text(
+                                'Key Management Testing',
+                                textAlign: TextAlign.start,
+                                style: Theme.of(context).textTheme.subtitle2,
+                              ),
                             ),
                           ),
                           Visibility(


### PR DESCRIPTION
### Types
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which improves code quality - QA thoroughly )
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (updates that would not affect or change the code involving the app itself)

### Changes
- Hide Key Management Testing heading behind debug flag

This has come about as a repurposing of the `Proxy Settings` screen as a more generic "unauth'd settings" one.

#### 🔮 Features
#### 🐛 Fixes
#### 🔒 Security 
#### 🛠 Performance
#### 📐 Refactoring

### Media (if applicable)
    
### QA

- [ ] Signup
- [ ] Login
- [ ] Logout
- [ ] Unencrypted Chat 
- [ ] Encrypted Chat 
- [ ] Group Chats
- [ ] Profile Changes
- [ ] Theming Changes
- [ ] Force Kill and Restart

### Final Checklist
 
- [x] All associated issues have been linked to PR
- [ ] All necessary changes made to the documentation
- [ ] Parties interested in these changes have been notified
