### PR TITLE
[Feature] Change message size

### DIFF
--- a/lib/store/settings/theme-settings/selectors.dart
+++ b/lib/store/settings/theme-settings/selectors.dart
@@ -314,6 +314,17 @@ String selectMessageSizeString(MessageSize messageSize) {
   return enumToString(messageSize);
 }
 
+double selectMessageSizeDouble(MessageSize messageSize) {
+  switch (messageSize) {
+    case MessageSize.Small:
+      return 10;
+    case MessageSize.Large:
+      return 14;
+    default:
+      return 12;
+  }
+}
+
 String selectAvatarShapeString(AvatarShape avatarShape) {
   return enumToString(avatarShape);
 }

--- a/lib/views/home/chat/widgets/message-list.dart
+++ b/lib/views/home/chat/widgets/message-list.dart
@@ -17,6 +17,7 @@ import 'package:syphon/store/rooms/selectors.dart';
 import 'package:syphon/store/settings/chat-settings/selectors.dart';
 import 'package:syphon/store/settings/models.dart';
 import 'package:syphon/store/settings/theme-settings/model.dart';
+import 'package:syphon/store/settings/theme-settings/selectors.dart';
 import 'package:syphon/store/user/model.dart';
 import 'package:syphon/store/user/selectors.dart';
 import 'package:syphon/views/widgets/lifecycle.dart';
@@ -228,6 +229,7 @@ class MessageListState extends State<MessageList> with Lifecycle<MessageList> {
                       displayName: displayName,
                       currentName: props.currentUser.userId,
                       themeType: props.themeType,
+                      messageSize: selectMessageSizeDouble(props.messageSize),
                       color: props.chatColorPrimary ?? color,
                       luminance: luminance,
                       timeFormat: props.timeFormat,
@@ -262,6 +264,7 @@ class _Props extends Equatable {
   final Room room;
   final User currentUser;
   final ThemeType themeType;
+  final MessageSize messageSize;
   final TimeFormat timeFormat;
   final Map<String, User> users;
   final List<Message> messages;
@@ -271,6 +274,7 @@ class _Props extends Equatable {
   const _Props({
     required this.room,
     required this.themeType,
+    required this.messageSize,
     required this.users,
     required this.messages,
     required this.messagesRaw,
@@ -290,6 +294,7 @@ class _Props extends Equatable {
         timeFormat:
             store.state.settingsStore.timeFormat24Enabled ? TimeFormat.hr24 : TimeFormat.hr12,
         themeType: store.state.settingsStore.themeSettings.themeType,
+        messageSize: store.state.settingsStore.themeSettings.messageSize,
         currentUser: store.state.authStore.user,
         chatColorPrimary: selectBubbleColor(store, roomId),
         room: selectRoom(id: roomId, state: store.state),

--- a/lib/views/home/settings/settings-theme-screen.dart
+++ b/lib/views/home/settings/settings-theme-screen.dart
@@ -357,6 +357,7 @@ class _Props extends Equatable {
         language,
         fontName,
         fontSize,
+        messageSize,
         avatarShape,
         roomTypeBadgesEnabled,
         mainFabType,

--- a/lib/views/widgets/messages/message.dart
+++ b/lib/views/widgets/messages/message.dart
@@ -46,6 +46,7 @@ class MessageWidget extends StatelessWidget {
     this.currentName,
     this.themeType = ThemeType.Light,
     this.fontSize = 14.0,
+    this.messageSize = 12.0,
     this.timeFormat = TimeFormat.hr12,
     this.color,
     this.luminance = 0.0,
@@ -67,6 +68,7 @@ class MessageWidget extends StatelessWidget {
 
   final int lastRead;
   final double fontSize;
+  final double messageSize;
   final TimeFormat timeFormat;
 
   final Color? color;
@@ -464,7 +466,7 @@ class MessageWidget extends StatelessWidget {
                                       child: Text(
                                         displayName ?? formatSender(message.sender!),
                                         style: TextStyle(
-                                          fontSize: 12,
+                                          fontSize: messageSize,
                                           color: textColor,
                                           fontWeight: FontWeight.w600,
                                         ),
@@ -539,8 +541,7 @@ class MessageWidget extends StatelessWidget {
                                             color: textColor,
                                             fontStyle: fontStyle,
                                             fontWeight: FontWeight.w300,
-                                            fontSize:
-                                                Theme.of(context).textTheme.subtitle2!.fontSize,
+                                            fontSize: messageSize,
                                           ),
                                         ),
                                       ),
@@ -595,7 +596,7 @@ class MessageWidget extends StatelessWidget {
                                               child: Text(
                                                 status,
                                                 style: TextStyle(
-                                                  fontSize: 12,
+                                                  fontSize: messageSize,
                                                   color: textColor,
                                                   fontWeight: FontWeight.w100,
                                                 ),


### PR DESCRIPTION
### Types
- [x] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which improves code quality - QA thoroughly )
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (updates that would not affect or change the code involving the app itself)

### Changes
Somehow this is a fix because like in #554 you see a button in the settings but it does nothing. But it could also be a feature because messageSize wasn't even used anywhere (yet).
Now you can change the message size in the settings and the message size of messages in chats will really change.

This solves #554.

### Media (if applicable)
Here you can see the different message size options (screenshots from the public Syphon chat):

MessageSize - Small (10)
![messagesize_small](https://user-images.githubusercontent.com/100708552/217606886-4e2fa5f0-cc74-4b71-815d-6f322ed987fd.png)

MessageSize - Default (12)
![messagesize_default](https://user-images.githubusercontent.com/100708552/217606969-d28d7276-e16e-4201-bf4e-cd8b70aacd1f.png)


MessageSize - Large (14)
![messagesize_large](https://user-images.githubusercontent.com/100708552/217606964-688d6500-7cc3-428a-be5f-a22541b31b2a.png)

### QA

- [ ] Signup
- [ ] Login
- [ ] Logout
- [ ] Unencrypted Chat 
- [ ] Encrypted Chat 
- [ ] Group Chats
- [ ] Profile Changes
- [ ] Theming Changes
- [ ] Force Kill and Restart

### Final Checklist
 
- [x] All associated issues have been linked to PR
- [ ] All necessary changes made to the documentation
- [ ] Parties interested in these changes have been notified
- [ ] Linter has been run on all code in the PR
