### PR TITLE
Border radius for code elements (Markdown)

### DIFF
--- a/lib/views/widgets/messages/message.dart
+++ b/lib/views/widgets/messages/message.dart
@@ -185,6 +185,7 @@ class MessageWidget extends StatelessWidget {
 
     var textColor = Colors.white;
     Color anchorColor = Colors.blue;
+    var backgroundColor = Theme.of(context).scaffoldBackgroundColor;
     var showSender = !messageOnly && !isUserSent; // nearly always show the sender
     var luminance = this.luminance;
 
@@ -529,10 +530,10 @@ class MessageWidget extends StatelessWidget {
                                             color: replyColor,
                                             borderRadius: const BorderRadius.only(
                                               //TODO: shape similar to bubbleBorder
-                                              topLeft: Radius.circular(4),
-                                              topRight: Radius.circular(4),
-                                              bottomLeft: Radius.circular(4),
-                                              bottomRight: Radius.circular(4),
+                                              topLeft: Radius.circular(12),
+                                              topRight: Radius.circular(12),
+                                              bottomLeft: Radius.circular(12),
+                                              bottomRight: Radius.circular(12),
                                             ),
                                           ),
                                           p: TextStyle(
@@ -541,6 +542,12 @@ class MessageWidget extends StatelessWidget {
                                             fontWeight: FontWeight.w300,
                                             fontSize:
                                                 Theme.of(context).textTheme.subtitle2!.fontSize,
+                                          ),
+                                          codeblockDecoration: ShapeDecoration(
+                                            color: backgroundColor,
+                                            shape: RoundedRectangleBorder(
+                                              borderRadius: BorderRadius.circular(12),
+                                            ),
                                           ),
                                         ),
                                       ),


### PR DESCRIPTION
### Types
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which improves code quality - QA thoroughly )
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (updates that would not affect or change the code involving the app itself)

### Changes

#### 🐛 Fixes
Added a border radius to code elements in the markdown part of a message bubble. And because I added the radius there anyway I decided to take a radius of 10 for both code elements and blockquote elements. I think it looks better than a small radius (blockquote element had radius 4 before the change).

The screenshot shows a code element and blockquote elements:
![border_radius](https://user-images.githubusercontent.com/100708552/218257013-8e26d07a-6f04-4899-8186-0a5f20fa1022.png)

The reason for this PR is that I wanted to solve #480.

    
### QA

- [ ] Signup
- [ ] Login
- [ ] Logout
- [ ] Unencrypted Chat 
- [ ] Encrypted Chat 
- [ ] Group Chats
- [ ] Profile Changes
- [ ] Theming Changes
- [ ] Force Kill and Restart

### Final Checklist
 
- [x] All associated issues have been linked to PR
- [ ] All necessary changes made to the documentation
- [ ] Parties interested in these changes have been notified
- [ ] Linter has been run on all code in the PR
