### PR TITLE
applicationIdSuffix and different app name for android debug version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -68,9 +68,12 @@ android {
    buildTypes {
        release {
            signingConfig signingConfigs.release
+           resValue "string", "app_name", "Syphon"
        }
        debug {
             signingConfig signingConfigs.debug
+            resValue "string", "app_name", "Syphon Debug"
+            applicationIdSuffix ".debug"
         }
    }
     externalNativeBuild {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
 
     <application
         android:name="${applicationName}"
-        android:label="Syphon"
+        android:label="@string/app_name"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher">
         <service


### PR DESCRIPTION
I added an applicationIdSuffix for the Android version so you can install both release **and** debug version parallel. Before this when you had the official app installed and tested a debug build the official app was replaced with the debug version so you had to login again after testing.

Another change is that I made the name of the app depending on the product flavor. This way you can distinguish between release and debug version. Also nice for people that use the official app and want to develop for Syphon. 