### PR TITLE
changed color of email button to blue

### DIFF
--- a/lib/views/home/HomeAppBar.dart
+++ b/lib/views/home/HomeAppBar.dart
@@ -75,7 +75,7 @@ class AppBarHome extends HookWidget implements PreferredSizeWidget {
         builder: (dialogContext) => DialogOptions(
           title: 'How can we help?',
           content: Strings.contentSupportDialog,
-          confirmStyle: const TextStyle(color: Colors.grey),
+          confirmStyle: const TextStyle(color: Colors.blue),
           dismissStyle: const TextStyle(color: Colors.blue),
           dismissText: 'Join Support chat',
           confirmText: 'Email our team',


### PR DESCRIPTION
Changed the color of the button "Email our team" to blue because otherwise it seems like it is disabled.

Edit: In other dialogs the choice of these colors is okay when one button starts an action and one button closes the dialog. But in this case both buttons have a similar meaning because both start actions that help a user to contact the developers. And if they have different colors and one even is grey it confuses the user.

On the screenshot you can see how it was before the change:

![help_dialog](https://github.com/syphon-org/syphon/assets/100708552/20e39479-7082-4a45-a513-a269e932b0f6)
