### PR TITLE
Added case for didChangeAppLifecycleState to be exhaustive (necessary for Flutter >3.13.2)

### DIFF
--- a/lib/views/syphon.dart
+++ b/lib/views/syphon.dart
@@ -163,6 +163,8 @@ class SyphonState extends State<Syphon> with WidgetsBindingObserver {
         store.dispatch(setBackgrounded(backgrounded: true));
       case AppLifecycleState.inactive:
         break;
+      case AppLifecycleState.hidden:
+        break;
     }
   }
 


### PR DESCRIPTION
To be able to build the application I had first to update Flutter. But for Flutter 3.13.2 it was also necessary to add a new case for _AppLifecycleState_.